### PR TITLE
Patch enforce_rigid_bones.py

### DIFF
--- a/ajc27_freemocap_blender_addon/core_functions/bones/enforce_rigid_bones.py
+++ b/ajc27_freemocap_blender_addon/core_functions/bones/enforce_rigid_bones.py
@@ -37,7 +37,7 @@ def enforce_rigid_bones(handler: FreemocapDataHandler,
         tail_name = bone['tail']
 
         for frame_number, raw_length in enumerate(bone['lengths']):
-            if np.isnan(raw_length):
+            if np.isnan(raw_length) or raw_length == 0:
                 continue
 
             head_position = original_trajectories[head_name][frame_number, :]


### PR DESCRIPTION
Fix the division by 0 error by continuing if raw bone length is 0. 
We were already continuing if the raw length was nan, so this shouldn't have adverse effects aside from preventing the error