### PR TITLE
Patch divide by zero

### DIFF
--- a/ajc27_freemocap_blender_addon/core_functions/bones/enforce_rigid_bones.py
+++ b/ajc27_freemocap_blender_addon/core_functions/bones/enforce_rigid_bones.py
@@ -46,7 +46,11 @@ def enforce_rigid_bones(handler: FreemocapDataHandler,
             bone_vector = tail_position - head_position
 
             # Get the normalized bone vector by dividing the bone_vector by its length
-            bone_vector_norm = bone_vector / raw_length
+            try:
+              bone_vector_norm = bone_vector / raw_length
+            except ZeroDivisionError:
+              raw_length = 0.0001
+              bone_vector_norm = bone_vector / raw_length
 
             # Calculate the new tail position delta by multiplying the normalized bone vector by the difference of desired_length and original_length
             position_delta = bone_vector_norm * (desired_length - raw_length)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ajc27_freemocap_blender_addon"
-version = "0.2.13"
+version = "0.2.14"
 description = "A Blender Add-on for working with Freemocap Data (based on @ajc27's addon)"
 authors = ["Skelly FreeMoCap <info@freemocap.org>"]
 license = "AGPLv3"


### PR DESCRIPTION
The zero test doesn't catch all of the division by zero errors because of floating point errors. This catches floating point errors in a try/except block and sets the raw_length to a small non-zero number. I checked with AJC and this should result in good blender output.