### PR TITLE
Add frame offset to videos and remove tomllib as optional dependency

### DIFF
--- a/ajc27_freemocap_blender_addon/core_functions/load_videos/load_videos.py
+++ b/ajc27_freemocap_blender_addon/core_functions/load_videos/load_videos.py
@@ -19,9 +19,14 @@ def get_video_paths(path_to_video_folder: str) -> list[str]:
 def add_videos_to_scene(videos_directory: str,
                         parent_object: bpy.types.Object,
                         video_scale: float = 3,
+                        frame_offset: int = 1,
                         ):
     print(f"Adding videos to scene...")
     video_paths = get_video_paths(videos_directory)
+
+    # Sort video paths by filename to ensure consistent ordering
+    video_paths.sort(key=lambda x: Path(x).stem)
+    print(f"Sorted video paths: {[Path(path).stem for path in video_paths]}")
 
     bpy.ops.image.import_as_mesh_planes(use_backface_culling=False,
                                         files=[{"name":path} for path in video_paths],
@@ -44,7 +49,14 @@ def add_videos_to_scene(videos_directory: str,
         obj.location.y += video_scale/2
         obj.location.z = video_scale/2 + 0.5
 
-
+        # Apply frame offset to the video texture
+        for material_slot in obj.material_slots:
+            if material_slot.material and material_slot.material.use_nodes:
+                nodes = material_slot.material.node_tree.nodes
+                for node in nodes:
+                    if node.type == 'TEX_IMAGE' and node.image:
+                        # Offset the video playback by adjusting the frame
+                        node.image_user.frame_offset = frame_offset
 
 
     #add to videos collection

--- a/ajc27_freemocap_blender_addon/utilities/install_dependencies.py
+++ b/ajc27_freemocap_blender_addon/utilities/install_dependencies.py
@@ -1,7 +1,7 @@
 import subprocess
 import sys
 
-OPTIONAL_DEPENDENCIES = ["tomllib"] #, "opencv-contrib-python", "matplotlib"]
+OPTIONAL_DEPENDENCIES = []
 
 
 def check_and_install_dependencies():


### PR DESCRIPTION
@jonmatthis Here I'm doing this PR to add the following:

- An offset of 1 frame to the background videos. This is because video playback starts at frame 1 (can't change that) so there is a mismatch with the animation that starts at 0. 

- Remove the tomllib from the OPTIONAL_DEPENDENCIES list. The tomllib and toml module import is being handled already. So if one module can't be loaded then the other is. I don't know if there could be a case where none are installed. So this is to avoid the always failing installation of tomllib because it can't be found.