### PR TITLE
Improve Metahuman rest pose

### DIFF
--- a/ajc27_freemocap_blender_addon/core_functions/export_3d_model/export_3d_model.py
+++ b/ajc27_freemocap_blender_addon/core_functions/export_3d_model/export_3d_model.py
@@ -168,7 +168,7 @@ def export_3d_model(
     for marker in empties_parent.children:
         marker.matrix_world.translation = current_markers_position[marker.name]
         # Insert keyframe in the start frame
-        marker.keyframe_insert(data_path="location", frame=bpy.context.scene.frame_start)
+        # marker.keyframe_insert(data_path="location", frame=bpy.context.scene.frame_start)
 
 
     if restore_defaults_after_export:
@@ -234,6 +234,9 @@ def export_3d_model(
                         bone.parent = armature.data.edit_bones['pelvis.L']
                     bone.use_connect = True
 
+                if 'shoulder' in bone.name or 'neck' in bone.name:
+                    bone.use_connect = True
+
             # Set Object Mode
             bpy.ops.object.mode_set(mode='OBJECT')
             armature.select_set(False)
@@ -260,7 +263,7 @@ def export_3d_model(
             armature.select_set(False)
 
         if rest_pose_type == 'metahuman':
-            # Restore the hand bone connstraints target markers
+            # Restore the hand bone constraints target markers
             # TODO: Delete this code if the default target markers are not hand_middle and hand_thumb_cmc
             for side in ['left', 'right']:
                 hand_bone = armature.pose.bones['hand' + '.' + side[0].upper()]
@@ -279,6 +282,32 @@ def export_3d_model(
 
                 hand_bone.constraints['Damped Track'].target = hand_middle
                 hand_bone.constraints['Locked Track'].target = hand_thumb_cmc
+
+
+            # Remove the Metahuman_Spine_01_Correction constraint if it exists
+            if "Metahuman_Spine_01_Correction" in armature.pose.bones["spine"].constraints:
+                constraint = armature.pose.bones["spine"].constraints["Metahuman_Spine_01_Correction"]
+                armature.pose.bones["spine"].constraints.remove(constraint)
+
+            # Remove the Metahuman_Spine_04_Correction constraint if it exists
+            if "Metahuman_Spine_04_Correction" in armature.pose.bones["spine.001"].constraints:
+                constraint = armature.pose.bones["spine.001"].constraints["Metahuman_Spine_04_Correction"]
+                armature.pose.bones["spine.001"].constraints.remove(constraint)
+
+            # Remove the Metahuman_Neck_Location_Correction constraint if it exists
+            if "Metahuman_Neck_Location_Correction" in armature.pose.bones["neck"].constraints:
+                constraint = armature.pose.bones["neck"].constraints["Metahuman_Neck_Location_Correction"]
+                armature.pose.bones["neck"].constraints.remove(constraint)
+
+            # Remove the Metahuman_Neck_Correction constraint if it exists
+            if "Metahuman_Neck_Correction" in armature.pose.bones["neck"].constraints:
+                constraint = armature.pose.bones["neck"].constraints["Metahuman_Neck_Correction"]
+                armature.pose.bones["neck"].constraints.remove(constraint)
+
+            # Remove the Metahuman_Head_Correction constraint if it exists
+            if "Metahuman_Head_Correction" in armature.pose.bones["face"].constraints:
+                constraint = armature.pose.bones["face"].constraints["Metahuman_Head_Correction"]
+                armature.pose.bones["face"].constraints.remove(constraint)            
 
         if rest_pose_type == 'daz_g8.1':
             # Remove the DazG8.1_Face_Correction constraint if it exists

--- a/ajc27_freemocap_blender_addon/core_functions/export_3d_model/export_3d_model.py
+++ b/ajc27_freemocap_blender_addon/core_functions/export_3d_model/export_3d_model.py
@@ -1,360 +1,280 @@
-import bpy
 import os
 
-from ajc27_freemocap_blender_addon.core_functions.export_3d_model.helpers.set_armature_pose_by_markers import set_armature_pose_by_markers
-from ajc27_freemocap_blender_addon.core_functions.export_3d_model.helpers.set_armature_rest_pose import set_armature_rest_pose
-from ajc27_freemocap_blender_addon.core_functions.export_3d_model.helpers.bone_naming_mapping import bone_naming_mapping
-from ajc27_freemocap_blender_addon.core_functions.meshes.skelly_mesh.helpers.mesh_utilities import get_bone_info
-from ajc27_freemocap_blender_addon.core_functions.meshes.skelly_mesh.strategies.attach_skelly_by_vertex_groups import align_and_parent_vertex_groups_to_armature
+import bpy
+
+from ajc27_freemocap_blender_addon.core_functions.export_3d_model.helpers.bone_naming_mapping import (
+    bone_naming_mapping,
+)
+from ajc27_freemocap_blender_addon.core_functions.export_3d_model.helpers.restore_daz_g8_1 import (
+    restore_daz_g8_1_edit_mode,
+    restore_daz_g8_1_pose_mode,
+)
+from ajc27_freemocap_blender_addon.core_functions.export_3d_model.helpers.restore_metahuman import (
+    restore_metahuman_edit_mode,
+    restore_metahuman_pose_mode,
+)
+from ajc27_freemocap_blender_addon.core_functions.export_3d_model.helpers.set_armature_pose_by_markers import (
+    set_armature_pose_by_markers,
+)
+from ajc27_freemocap_blender_addon.core_functions.export_3d_model.helpers.set_armature_rest_pose import (
+    set_armature_rest_pose,
+)
+from ajc27_freemocap_blender_addon.core_functions.meshes.skelly_mesh.helpers.mesh_utilities import (
+    get_bone_info,
+)
 from ajc27_freemocap_blender_addon.core_functions.meshes.skelly_mesh.helpers.skelly_vertex_groups import (
     _SKELLY_VERTEX_GROUPS,
+)
+from ajc27_freemocap_blender_addon.core_functions.meshes.skelly_mesh.strategies.attach_skelly_by_vertex_groups import (
+    align_and_parent_vertex_groups_to_armature,
 )
 
 
 def export_3d_model(
-        data_parent_empty: bpy.types.Object,
-        armature: bpy.types.Armature,
-        formats: list = ['fbx', 'bvh'],  # , 'gltf'],
-        destination_folder: str = '',
-        add_subfolder: bool = False,
-        rename_root_bone: bool = False,
-        bones_naming_convention: str = 'default',
-        rest_pose_type: str = 'default',
-        restore_defaults_after_export: bool = True,
-        fbx_add_leaf_bones: bool = True,
-        fbx_primary_bone_axis: str = 'Y',
-        fbx_secondary_bone_axis: str = 'X',
+    data_parent_empty: bpy.types.Object,
+    armature: bpy.types.Armature,
+    formats: list = None,
+    destination_folder: str = '',
+    add_subfolder: bool = False,
+    rename_root_bone: bool = False,
+    bones_naming_convention: str = 'default',
+    rest_pose_type: str = 'default',
+    restore_defaults_after_export: bool = True,
+    fbx_add_leaf_bones: bool = True,
+    fbx_primary_bone_axis: str = 'Y',
+    fbx_secondary_bone_axis: str = 'X',
 ) -> None:
-    # Deselect all objects
-    bpy.ops.object.select_all(action='DESELECT')
+    if formats is None:
+        formats = ['fbx', 'bvh']
 
-    # Set the frame to the scene start frame
-    bpy.context.scene.frame_set(bpy.context.scene.frame_start)
+    # 1. Setup and Preparation
+    _prepare_scene()
+    export_folder = _get_export_folder(destination_folder, add_subfolder)
+    mesh_object = [
+        obj for obj in data_parent_empty.children_recursive
+        if 'skelly_mesh' in obj.name
+    ][0]
+    empties_parent = [
+        obj for obj in data_parent_empty.children
+        if 'empties_parent' in obj.name
+    ][0]
 
-    armature_original_name = ''
-
-    # TODO - JSM - Do we need this?
-    if rename_root_bone:
-        # Save the original armature name to restore it after the export
-        armature_original_name = armature.name
-        # Rename the armature if its name is different from root
-        if armature.name != "root":
-            armature.name = "root"
-
-    if add_subfolder:
-        # Ensure the folder '3D_model' exists within the recording folder
-        export_folder = os.path.join(destination_folder, "3d_models")
-        os.makedirs(export_folder, exist_ok=True)
-    else:
-        export_folder = destination_folder
-
-    # Get references to the mesh object
-    mesh_object = [obj for obj in data_parent_empty.children_recursive if 'skelly_mesh' in obj.name][0]
-
-    # Change the rest pose if its type is different than default
+    # 2. Save Current State
+    armature_original_name = armature.name
+    current_bone_info = {}
     if rest_pose_type != 'default':
-        # Save the current rest pose with bone_info to restore it after the export
         current_bone_info = get_bone_info(armature)
-        # Set the export rest pose
+
+    current_markers_position = {
+        marker.name: marker.matrix_world.translation.copy()
+        for marker in empties_parent.children
+    }
+
+    # 3. Apply Export Configurations
+    if rename_root_bone and armature.name != "root":
+        armature.name = "root"
+
+    if rest_pose_type != 'default':
         set_armature_rest_pose(
             data_parent_empty=data_parent_empty,
             armature=armature,
             rest_pose_type=rest_pose_type
         )
-        # Align and parent the mesh to the armature
         align_and_parent_vertex_groups_to_armature(
             armature=armature,
             mesh_object=mesh_object,
             vertex_groups=_SKELLY_VERTEX_GROUPS
         )
 
-    # Get references to the empties_parent object
-    empties_parent = [obj for obj in data_parent_empty.children if 'empties_parent' in obj.name][0]
-
-    # Get the current frame action position of the markers and save it in a dictionary
-    current_markers_position = {}
-    for marker in empties_parent.children:
-        current_markers_position[marker.name] = marker.matrix_world.translation.copy()
-
-    # Set the markers position in frame 0 equal to the expected armature rest pose
-    # This is because the exported fbx armature gets its rest pose as the
-    # pose the armature has in the current frame before the export
-    # Might be a change in the internal export function.
     set_armature_pose_by_markers(
         data_parent_empty=data_parent_empty,
         armature=armature
     )
 
-    # Change the name of the bones according to the selected naming convention
     if bones_naming_convention != "default":
-        armature.select_set(True)
-        # Set Edit Mode
-        bpy.ops.object.mode_set(mode="EDIT")
+        _apply_bone_naming(armature, bones_naming_convention)
 
-        for bone in armature.data.bones:
-            if bone.name in bone_naming_mapping[bones_naming_convention]:
-                bone.name = bone_naming_mapping[bones_naming_convention][bone.name]
-
-        # Set Object Mode
-        bpy.ops.object.mode_set(mode="OBJECT")
-        armature.select_set(False)
-
-    # Export the file formats
-    for format in formats:
-        
-        # Set the export file name based on the recording folder name
-        export_file_name = data_parent_empty.name.removesuffix("_origin") + f".{format}"
-        export_path = os.path.join(export_folder, export_file_name)
+    # 4. Perform Format Exports
+    export_file_base = data_parent_empty.name.removesuffix("_origin")
+    for export_format in formats:
+        export_path = os.path.join(
+            export_folder, f"{export_file_base}.{export_format}"
+        )
         try:
-            if format == "fbx":
-                # Select the armature
-                armature.select_set(True)
-
-                # Select the meshes parented to the armature
-                child_objects = [obj for obj in bpy.data.objects if obj.parent == armature]
-                for child_object in child_objects:
-                    child_object.select_set(True)
-
-                bpy.ops.export_scene.fbx(
-                    filepath=export_path,
-                    check_existing=True,
-                    use_selection=True,
-                    bake_anim=True,
-                    bake_anim_use_all_bones=True,
-                    bake_anim_use_nla_strips=False,
-                    bake_anim_use_all_actions=False,
-                    bake_anim_force_startend_keying=True,
-                    use_mesh_modifiers=True,
-                    add_leaf_bones=fbx_add_leaf_bones,
-                    bake_anim_step=1.0,
-                    bake_anim_simplify_factor=0.0,
-                    armature_nodetype='NULL',
-                    primary_bone_axis=fbx_primary_bone_axis,
-                    secondary_bone_axis=fbx_secondary_bone_axis,
-                )
-
-            elif format == "bvh":
-                armature.select_set(True)
-                # set armature as active object
-                bpy.context.view_layer.objects.active = armature
-
-                bpy.ops.export_anim.bvh(
-                    filepath=export_path,
-                    check_existing=True,
-                    frame_start=bpy.context.scene.frame_start,
-                    frame_end=bpy.context.scene.frame_end,
-                    root_transform_only=False,
-                    global_scale=1.0,
-                )
-
-            elif format == "gltf":
-                # TODO - Fix glTF export of animations - output appears broken
-                bpy.ops.export_scene.gltf(
-                    filepath=export_path,
-                    check_existing=True,
-                    export_cameras=True,
-                    export_lights=True,
-                    use_visible=True,
-                )
-            else:
-                raise ValueError(f"Unsupported file format: {format}")
+            _export_format(
+                export_format, export_path, armature, fbx_add_leaf_bones,
+                fbx_primary_bone_axis, fbx_secondary_bone_axis
+            )
         except Exception as e:
-            print(f"Error exporting {format} file: {e}")
+            print(f"Error exporting {export_format} file: {e}")
             raise
 
+    # 5. Restore Original State
     bpy.ops.object.select_all(action='DESELECT')
-
-    # Restore (keyframe insert) the position of the markers in the start frame
     for marker in empties_parent.children:
         marker.matrix_world.translation = current_markers_position[marker.name]
-        # Insert keyframe in the start frame
-        # marker.keyframe_insert(data_path="location", frame=bpy.context.scene.frame_start)
-
 
     if restore_defaults_after_export:
-        # Restore the name of the bones 
-        if bones_naming_convention != "default":
-            armature.select_set(True)
-            
-            # Get the inverse mapping of the bone_naming_mapping
-            inverse_bone_naming_mapping = {v: k for k, v in bone_naming_mapping[bones_naming_convention].items()}
+        _restore_scene_defaults(
+            armature=armature,
+            data_parent_empty=data_parent_empty,
+            mesh_object=mesh_object,
+            armature_original_name=armature_original_name,
+            current_bone_info=current_bone_info,
+            rename_root_bone=rename_root_bone,
+            bones_naming_convention=bones_naming_convention,
+            rest_pose_type=rest_pose_type
+        )
 
-            # Set Edit Mode
-            bpy.ops.object.mode_set(mode="EDIT")
 
-            for bone in armature.data.bones:
-                if bone.name in inverse_bone_naming_mapping:
-                    bone.name = inverse_bone_naming_mapping[bone.name]
+# --- Helper Functions ---
 
-            # Set Object Mode
-            bpy.ops.object.mode_set(mode="OBJECT")
-            armature.select_set(False)
 
-        # Restore the rest pose of the armature if it was changed
-        if rest_pose_type != "default":
-            # Deselect all objects
-            bpy.ops.object.select_all(action='DESELECT')
-            # Select the armature
-            armature.select_set(True)
+def _prepare_scene():
+    """Deselect all objects and set frame to start."""
+    bpy.ops.object.select_all(action='DESELECT')
+    bpy.context.scene.frame_set(bpy.context.scene.frame_start)
 
-            # Enter Edit Mode
-            bpy.ops.object.mode_set(mode='EDIT')
 
-            # Set the rest pose rotations
-            for bone in armature.data.edit_bones:
-                if bone.name in current_bone_info:
-                    bone.head = current_bone_info[bone.name]['head_position']
-                    bone.tail = current_bone_info[bone.name]['tail_position']
-                    bone.roll = current_bone_info[bone.name]['roll']
+def _get_export_folder(destination_folder: str, add_subfolder: bool) -> str:
+    """Determine the final export folder path."""
+    if add_subfolder:
+        export_folder = os.path.join(destination_folder, "3d_models")
+        os.makedirs(export_folder, exist_ok=True)
+        return export_folder
+    return destination_folder
 
-            # Set Object Mode
-            bpy.ops.object.mode_set(mode='OBJECT')
-            armature.select_set(False)
 
-            # Align and parent the mesh to the armature
-            align_and_parent_vertex_groups_to_armature(
-                armature=armature,
-                mesh_object=mesh_object,
-                vertex_groups=_SKELLY_VERTEX_GROUPS
-            )
+def _apply_bone_naming(armature: bpy.types.Object, naming_convention: str):
+    """Rename bones according to the selected naming convention."""
+    armature.select_set(True)
+    bpy.ops.object.mode_set(mode="EDIT")
+    for bone in armature.data.bones:
+        if bone.name in bone_naming_mapping[naming_convention]:
+            bone.name = bone_naming_mapping[naming_convention][bone.name]
+    bpy.ops.object.mode_set(mode="OBJECT")
+    armature.select_set(False)
 
-        # In case the rest pose type is metahuman or daz_g8.1, reparent the thigh bones to the pelvis.R and pelvis.L
-        if rest_pose_type in ('metahuman', 'daz_g8.1'):
-            # Select the armature
-            armature.select_set(True)
 
-            # Enter Edit Mode
-            bpy.ops.object.mode_set(mode='EDIT')
+def _export_format(
+    export_format: str,
+    export_path: str,
+    armature: bpy.types.Object,
+    fbx_add_leaf_bones: bool,
+    fbx_primary_bone_axis: str,
+    fbx_secondary_bone_axis: str
+):
+    """Route export to the appropriate format-specific function."""
+    if export_format == "fbx":
+        armature.select_set(True)
+        child_objects = [
+            obj for obj in bpy.data.objects if obj.parent == armature
+        ]
+        for child_object in child_objects:
+            child_object.select_set(True)
 
-            for bone in armature.data.edit_bones:
-                if 'thigh' in bone.name:
-                    if 'thigh.R' in bone.name:
-                        bone.parent = armature.data.edit_bones['pelvis.R']
-                    elif 'thigh.L' in bone.name:
-                        bone.parent = armature.data.edit_bones['pelvis.L']
-                    bone.use_connect = True
+        bpy.ops.export_scene.fbx(
+            filepath=export_path,
+            check_existing=True,
+            use_selection=True,
+            bake_anim=True,
+            bake_anim_use_all_bones=True,
+            bake_anim_use_nla_strips=False,
+            bake_anim_use_all_actions=False,
+            bake_anim_force_startend_keying=True,
+            use_mesh_modifiers=True,
+            add_leaf_bones=fbx_add_leaf_bones,
+            bake_anim_step=1.0,
+            bake_anim_simplify_factor=0.0,
+            armature_nodetype='NULL',
+            primary_bone_axis=fbx_primary_bone_axis,
+            secondary_bone_axis=fbx_secondary_bone_axis,
+        )
+    elif export_format == "bvh":
+        armature.select_set(True)
+        bpy.context.view_layer.objects.active = armature
 
-                if 'shoulder' in bone.name or 'neck' in bone.name:
-                    bone.use_connect = True
+        bpy.ops.export_anim.bvh(
+            filepath=export_path,
+            check_existing=True,
+            frame_start=bpy.context.scene.frame_start,
+            frame_end=bpy.context.scene.frame_end,
+            root_transform_only=False,
+            global_scale=1.0,
+        )
+    elif export_format == "gltf":
+        # TODO - Fix glTF export of animations - output appears broken
+        bpy.ops.export_scene.gltf(
+            filepath=export_path,
+            check_existing=True,
+            export_cameras=True,
+            export_lights=True,
+            use_visible=True,
+        )
+    else:
+        raise ValueError(f"Unsupported file format: {export_format}")
 
-            # Set Object Mode
-            bpy.ops.object.mode_set(mode='OBJECT')
-            armature.select_set(False)
 
-        # Recreate the thumb.carpal bones if the rest pose type is metahuman
-        if rest_pose_type in ('metahuman', 'daz_g8.1'):
-            # Select the armature
-            armature.select_set(True)
+def _restore_scene_defaults(
+    armature: bpy.types.Object,
+    data_parent_empty: bpy.types.Object,
+    mesh_object: bpy.types.Object,
+    armature_original_name: str,
+    current_bone_info: dict,
+    rename_root_bone: bool,
+    bones_naming_convention: str,
+    rest_pose_type: str
+):
+    """Restore armature, bones, mesh and names to their original state."""
 
-            # Enter Edit Mode
-            bpy.ops.object.mode_set(mode='EDIT')
+    # --- EDIT MODE PASS ---
+    bpy.ops.object.select_all(action='DESELECT')
+    armature.select_set(True)
+    bpy.ops.object.mode_set(mode='EDIT')
 
-            for side in ['.L', '.R']:
-                if 'thumb.carpal' + side not in armature.data.edit_bones:
-                    new_bone = armature.data.edit_bones.new(name='thumb.carpal' + side)
-                    new_bone.head = armature.data.edit_bones['hand' + side].head.copy()
-                    new_bone.tail = armature.data.edit_bones['thumb.01' + side].head.copy()
-                    new_bone.roll = 0.0
-                    new_bone.parent = armature.data.edit_bones['hand' + side]
-                    new_bone.use_connect = False
+    # Restore bone names
+    if bones_naming_convention != "default":
+        inverse_mapping = {
+            v: k for k, v in
+            bone_naming_mapping[bones_naming_convention].items()
+        }
+        for bone in armature.data.bones:
+            if bone.name in inverse_mapping:
+                bone.name = inverse_mapping[bone.name]
 
-            # Set Object Mode
-            bpy.ops.object.mode_set(mode='OBJECT')
-            armature.select_set(False)
+    # Restore rest pose and rig-specific bone structure
+    if rest_pose_type != "default":
+        for bone in armature.data.edit_bones:
+            if bone.name in current_bone_info:
+                bone.head = current_bone_info[bone.name]['head_position']
+                bone.tail = current_bone_info[bone.name]['tail_position']
+                bone.roll = current_bone_info[bone.name]['roll']
 
         if rest_pose_type == 'metahuman':
-            # Restore the hand bone constraints target markers
-            # TODO: Delete this code if the default target markers are not hand_middle and hand_thumb_cmc
-            for side in ['left', 'right']:
-                hand_bone = armature.pose.bones['hand' + '.' + side[0].upper()]
+            restore_metahuman_edit_mode(armature)
+        elif rest_pose_type == 'daz_g8.1':
+            restore_daz_g8_1_edit_mode(armature)
 
-                # Get the hand_middle
-                hand_middle = [
-                    marker for marker in data_parent_empty.children_recursive
-                    if side + '_hand_middle' == marker.name or side + '_hand_middle.' in marker.name # Consider suffixes like .001
-                ][0]
+    bpy.ops.object.mode_set(mode='OBJECT')
+    armature.select_set(False)
 
-                # Get the hand_thumb_cmc
-                hand_thumb_cmc = [
-                    marker for marker in data_parent_empty.children_recursive
-                    if side + '_hand_thumb_cmc' in marker.name
-                ][0]
+    # Re-align mesh based on restored pose
+    if rest_pose_type != "default":
+        align_and_parent_vertex_groups_to_armature(
+            armature=armature,
+            mesh_object=mesh_object,
+            vertex_groups=_SKELLY_VERTEX_GROUPS
+        )
 
-                hand_bone.constraints['Damped Track'].target = hand_middle
-                hand_bone.constraints['Locked Track'].target = hand_thumb_cmc
+    # --- POSE MODE PASS ---
+    if rest_pose_type == 'metahuman':
+        restore_metahuman_pose_mode(armature, data_parent_empty)
+    elif rest_pose_type == 'daz_g8.1':
+        restore_daz_g8_1_pose_mode(armature)
 
+    # Restore original name
+    if rename_root_bone:
+        for obj in bpy.data.objects:
+            if obj.type == "ARMATURE" and obj.name == "root":
+                obj.name = armature_original_name
 
-            # Remove the Metahuman_Spine_01_Correction constraint if it exists
-            if "Metahuman_Spine_01_Correction" in armature.pose.bones["spine"].constraints:
-                constraint = armature.pose.bones["spine"].constraints["Metahuman_Spine_01_Correction"]
-                armature.pose.bones["spine"].constraints.remove(constraint)
-
-            # Remove the Metahuman_Spine_04_Correction constraint if it exists
-            if "Metahuman_Spine_04_Correction" in armature.pose.bones["spine.001"].constraints:
-                constraint = armature.pose.bones["spine.001"].constraints["Metahuman_Spine_04_Correction"]
-                armature.pose.bones["spine.001"].constraints.remove(constraint)
-
-            # Remove the Metahuman_Neck_Location_Correction constraint if it exists
-            if "Metahuman_Neck_Location_Correction" in armature.pose.bones["neck"].constraints:
-                constraint = armature.pose.bones["neck"].constraints["Metahuman_Neck_Location_Correction"]
-                armature.pose.bones["neck"].constraints.remove(constraint)
-
-            # Remove the Metahuman_Neck_Correction constraint if it exists
-            if "Metahuman_Neck_Correction" in armature.pose.bones["neck"].constraints:
-                constraint = armature.pose.bones["neck"].constraints["Metahuman_Neck_Correction"]
-                armature.pose.bones["neck"].constraints.remove(constraint)
-
-            # Remove the Metahuman_Head_Correction constraint if it exists
-            if "Metahuman_Head_Correction" in armature.pose.bones["face"].constraints:
-                constraint = armature.pose.bones["face"].constraints["Metahuman_Head_Correction"]
-                armature.pose.bones["face"].constraints.remove(constraint)            
-
-        if rest_pose_type == 'daz_g8.1':
-            # Remove the DazG8.1_Face_Correction constraint if it exists
-            if "DazG8.1_Face_Correction" in armature.pose.bones["face"].constraints:
-                constraint = armature.pose.bones["face"].constraints["DazG8.1_Face_Correction"]
-                armature.pose.bones["face"].constraints.remove(constraint)
-
-            # Remove the DazG8.1_Pelvis_Correction constraint if it exists
-            if "DazG8.1_Pelvis_Correction" in armature.pose.bones["pelvis"].constraints:
-                constraint = armature.pose.bones["pelvis"].constraints["DazG8.1_Pelvis_Correction"]
-                armature.pose.bones["pelvis"].constraints.remove(constraint)
-
-            # Remove the DazG8.1_Spine_Correction constraint if it exists
-            if "DazG8.1_Spine_Correction" in armature.pose.bones["spine"].constraints:
-                constraint = armature.pose.bones["spine"].constraints["DazG8.1_Spine_Correction"]
-                armature.pose.bones["spine"].constraints.remove(constraint)
-
-            # Remove the DazG8.1_Forearm_Bend_Correction constraint if it exists
-            for side in ['.L', '.R']:
-                forearm_bone_name = 'forearm' + side
-                if forearm_bone_name in armature.pose.bones:
-                    forearm_bone = armature.pose.bones[forearm_bone_name]
-                    if "DazG8.1_Forearm_Bend_Correction" in forearm_bone.constraints:
-                        constraint = forearm_bone.constraints["DazG8.1_Forearm_Bend_Correction"]
-                        forearm_bone.constraints.remove(constraint)
-
-            # Remove the forearm twist bones if they were created
-            armature.select_set(True)
-            bpy.ops.object.mode_set(mode='EDIT')
-            for side in ['.L', '.R']:
-                twist_bone_name = 'forearm_twist' + side
-                if twist_bone_name in armature.data.edit_bones:
-                    bone = armature.data.edit_bones[twist_bone_name]
-                    armature.data.edit_bones.remove(bone)
-
-            # Set Object Mode
-            bpy.ops.object.mode_set(mode='OBJECT')
-            armature.select_set(False)
-
-        # Restore the name of the armature object
-        if rename_root_bone:
-            for armature in bpy.data.objects:
-                if armature.type == "ARMATURE":
-                    # Restore the original armature name
-                    armature.name = armature_original_name
-
-    # Deselect all objects
-    bpy.ops.object.select_all(action='DESELECT')
-
-    return

--- a/ajc27_freemocap_blender_addon/core_functions/export_3d_model/helpers/rest_pose_types.py
+++ b/ajc27_freemocap_blender_addon/core_functions/export_3d_model/helpers/rest_pose_types.py
@@ -92,7 +92,7 @@ rest_pose_type_rotations = {
         },
         'spine': {
             'rotation' : (
-                m.radians(6),
+                m.radians(10.950077),
                 0,
                 0
             ),
@@ -100,7 +100,7 @@ rest_pose_type_rotations = {
         },
         'spine.001': {
             'rotation' : (
-                m.radians(-9.86320126530132),
+                m.radians(-8.532878),
                 0,
                 0
             ),

--- a/ajc27_freemocap_blender_addon/core_functions/export_3d_model/helpers/restore_daz_g8_1.py
+++ b/ajc27_freemocap_blender_addon/core_functions/export_3d_model/helpers/restore_daz_g8_1.py
@@ -1,0 +1,66 @@
+import bpy
+
+def restore_daz_g8_1_edit_mode(armature: bpy.types.Object):
+    """
+    Restore DAZ G8.1 specific bone structures in Edit Mode.
+    Must be called while the armature is in Edit Mode.
+    """
+    # Reparent the thigh bones to the pelvis
+    for bone in armature.data.edit_bones:
+        if 'thigh' in bone.name:
+            if 'thigh.R' in bone.name:
+                bone.parent = armature.data.edit_bones.get('pelvis.R')
+            elif 'thigh.L' in bone.name:
+                bone.parent = armature.data.edit_bones.get('pelvis.L')
+            bone.use_connect = True
+
+        if 'shoulder' in bone.name or 'neck' in bone.name:
+            bone.use_connect = True
+            
+    # Recreate the thumb.carpal bones
+    for side in ['.L', '.R']:
+        if 'thumb.carpal' + side not in armature.data.edit_bones:
+            hand_bone = armature.data.edit_bones.get('hand' + side)
+            thumb_01_bone = armature.data.edit_bones.get('thumb.01' + side)
+            if hand_bone and thumb_01_bone:
+                new_bone = armature.data.edit_bones.new(name='thumb.carpal' + side)
+                new_bone.head = hand_bone.head.copy()
+                new_bone.tail = thumb_01_bone.head.copy()
+                new_bone.roll = 0.0
+                new_bone.parent = hand_bone
+                new_bone.use_connect = False
+                
+    # Remove the forearm twist bones if they were created
+    for side in ['.L', '.R']:
+        twist_bone_name = 'forearm_twist' + side
+        if twist_bone_name in armature.data.edit_bones:
+            bone = armature.data.edit_bones[twist_bone_name]
+            armature.data.edit_bones.remove(bone)
+
+
+def restore_daz_g8_1_pose_mode(armature: bpy.types.Object):
+    """
+    Restore DAZ G8.1 specific constraints and settings in Pose Mode.
+    """
+    # Remove specific correction constraints
+    constraints_to_remove = {
+        "face": ["DazG8.1_Face_Correction"],
+        "pelvis": ["DazG8.1_Pelvis_Correction"],
+        "spine": ["DazG8.1_Spine_Correction"],
+    }
+    
+    for bone_name, constraint_names in constraints_to_remove.items():
+        if bone_name in armature.pose.bones:
+            bone = armature.pose.bones[bone_name]
+            for c_name in constraint_names:
+                if c_name in bone.constraints:
+                    bone.constraints.remove(bone.constraints[c_name])
+                    
+    # Forearm constraints
+    for side in ['.L', '.R']:
+        forearm_bone_name = 'forearm' + side
+        if forearm_bone_name in armature.pose.bones:
+            forearm_bone = armature.pose.bones[forearm_bone_name]
+            if "DazG8.1_Forearm_Bend_Correction" in forearm_bone.constraints:
+                constraint = forearm_bone.constraints["DazG8.1_Forearm_Bend_Correction"]
+                forearm_bone.constraints.remove(constraint)

--- a/ajc27_freemocap_blender_addon/core_functions/export_3d_model/helpers/restore_metahuman.py
+++ b/ajc27_freemocap_blender_addon/core_functions/export_3d_model/helpers/restore_metahuman.py
@@ -1,0 +1,74 @@
+import bpy
+
+def restore_metahuman_edit_mode(armature: bpy.types.Object):
+    """
+    Restore Metahuman specific bone structures in Edit Mode.
+    Must be called while the armature is in Edit Mode.
+    """
+    # Reparent the thigh bones to the pelvis
+    for bone in armature.data.edit_bones:
+        if 'thigh' in bone.name:
+            if 'thigh.R' in bone.name:
+                bone.parent = armature.data.edit_bones.get('pelvis.R')
+            elif 'thigh.L' in bone.name:
+                bone.parent = armature.data.edit_bones.get('pelvis.L')
+            bone.use_connect = True
+
+        if 'shoulder' in bone.name or 'neck' in bone.name:
+            bone.use_connect = True
+            
+    # Recreate the thumb.carpal bones
+    for side in ['.L', '.R']:
+        if 'thumb.carpal' + side not in armature.data.edit_bones:
+            hand_bone = armature.data.edit_bones.get('hand' + side)
+            thumb_01_bone = armature.data.edit_bones.get('thumb.01' + side)
+            if hand_bone and thumb_01_bone:
+                new_bone = armature.data.edit_bones.new(name='thumb.carpal' + side)
+                new_bone.head = hand_bone.head.copy()
+                new_bone.tail = thumb_01_bone.head.copy()
+                new_bone.roll = 0.0
+                new_bone.parent = hand_bone
+                new_bone.use_connect = False
+
+
+def restore_metahuman_pose_mode(armature: bpy.types.Object, data_parent_empty: bpy.types.Object):
+    """
+    Restore Metahuman specific constraints and settings in Pose Mode.
+    """
+    # Restore the hand bone constraints target markers
+    for side in ['left', 'right']:
+        hand_bone_name = 'hand' + '.' + side[0].upper()
+        if hand_bone_name in armature.pose.bones:
+            hand_bone = armature.pose.bones[hand_bone_name]
+
+            # Get the hand_middle
+            hand_middle = [
+                marker for marker in data_parent_empty.children_recursive
+                if side + '_hand_middle' == marker.name or side + '_hand_middle.' in marker.name
+            ]
+            
+            # Get the hand_thumb_cmc
+            hand_thumb_cmc = [
+                marker for marker in data_parent_empty.children_recursive
+                if side + '_hand_thumb_cmc' in marker.name
+            ]
+
+            if hand_middle and 'Damped Track' in hand_bone.constraints:
+                hand_bone.constraints['Damped Track'].target = hand_middle[0]
+            if hand_thumb_cmc and 'Locked Track' in hand_bone.constraints:
+                hand_bone.constraints['Locked Track'].target = hand_thumb_cmc[0]
+
+    # Remove specific correction constraints
+    constraints_to_remove = {
+        "spine": ["Metahuman_Spine_01_Correction"],
+        "spine.001": ["Metahuman_Spine_04_Correction"],
+        "neck": ["Metahuman_Neck_Location_Correction", "Metahuman_Neck_Correction"],
+        "face": ["Metahuman_Head_Correction"]
+    }
+    
+    for bone_name, constraint_names in constraints_to_remove.items():
+        if bone_name in armature.pose.bones:
+            bone = armature.pose.bones[bone_name]
+            for c_name in constraint_names:
+                if c_name in bone.constraints:
+                    bone.constraints.remove(bone.constraints[c_name])

--- a/ajc27_freemocap_blender_addon/core_functions/export_3d_model/helpers/set_armature_rest_pose.py
+++ b/ajc27_freemocap_blender_addon/core_functions/export_3d_model/helpers/set_armature_rest_pose.py
@@ -1,9 +1,302 @@
-import bpy
-from mathutils import Vector, Euler
 import math as m
 
-from ajc27_freemocap_blender_addon.core_functions.meshes.skelly_mesh.helpers.mesh_utilities import get_bone_info
-from ajc27_freemocap_blender_addon.core_functions.export_3d_model.helpers.rest_pose_types import rest_pose_type_rotations
+import bpy
+from mathutils import Euler, Vector
+
+from ajc27_freemocap_blender_addon.core_functions.export_3d_model.helpers.rest_pose_types import (
+    rest_pose_type_rotations,
+)
+from ajc27_freemocap_blender_addon.core_functions.meshes.skelly_mesh.helpers.mesh_utilities import (
+    get_bone_info,
+)
+
+
+def _get_marker(parent_empty: bpy.types.Object, substring: str) -> bpy.types.Object:
+    """Helper to find a marker by name substring."""
+    return next(
+        (marker for marker in parent_empty.children_recursive if substring in marker.name),
+        None
+    )
+
+
+def _add_damped_track(pose_bone, target, name, track_axis, influence):
+    """Helper to add a DAMPED_TRACK constraint."""
+    constraint = pose_bone.constraints.new('DAMPED_TRACK')
+    constraint.name = name
+    constraint.target = target
+    constraint.track_axis = track_axis
+    constraint.influence = influence
+    return constraint
+
+
+def _apply_base_rotations(
+    armature: bpy.types.Armature, bone_info: dict, rest_pose_rotations: dict
+):
+    for bone in armature.data.edit_bones:
+        if bone.name in rest_pose_rotations:
+            # If the bone is part of the palm, move its head to its parent
+            # as it is not connected and didn't move with its parent rotation
+            if 'palm' in bone.name or 'thumb.carpal' in bone.name:
+                bone.head = bone.parent.head
+
+            bone_vector = Vector([0, 0, bone_info[bone.name]['length']])
+
+            # Get the rotation matrix
+            rotation_matrix = Euler(
+                Vector(rest_pose_rotations[bone.name]['rotation']),
+                'XYZ',
+            ).to_matrix()
+
+            # Rotate the bone vector
+            bone.tail = bone.head + rotation_matrix @ bone_vector
+
+            # Assign the roll to the bone
+            bone.roll = rest_pose_rotations[bone.name]['roll']
+
+
+def _apply_metahuman_edit_mode(
+    armature: bpy.types.Armature, bone_info: dict, rest_pose_rotations: dict
+):
+    for bone in armature.data.edit_bones:
+        if 'thigh' in bone.name:
+            bone.use_connect = False
+            bone.parent = armature.data.edit_bones['pelvis']
+
+        if 'thumb.01' in bone.name:
+            thumb_side = 'left' if '.L' in bone.name else 'right'
+            bone.use_connect = False
+            # Set the new parent to the hand using uppercase first letter
+            bone.parent = armature.data.edit_bones[f'hand.{thumb_side[0].upper()}']
+
+            # Remove the thumb.carpal bone
+            thumb_carpal_name = f'thumb.carpal.{thumb_side[0].upper()}'
+            if thumb_carpal_name in armature.data.edit_bones:
+                armature.data.edit_bones.remove(
+                    armature.data.edit_bones[thumb_carpal_name]
+                )
+
+        # Disconnect the shoulder and neck bones from parent
+        # so spine.001 can have custom rotation
+        if 'shoulder' in bone.name or 'neck' in bone.name:
+            bone.use_connect = False
+
+    # Change the length of Spine.001 (spine_04) to compensate for new parent
+    spine_rotation = rest_pose_rotations['spine']['rotation'][0]
+    spine_len = bone_info['spine']['length']
+    spine_001_len = bone_info['spine.001']['length']
+    
+    # Law of cosines
+    spine_001_new_length = m.sqrt(
+        spine_len**2
+        + (spine_len + spine_001_len)**2
+        - 2 * spine_len * (spine_len + spine_001_len) * m.cos(spine_rotation)
+    )
+
+    armature.data.edit_bones['spine.001'].length = spine_001_new_length
+
+
+def _apply_metahuman_pose_mode(
+    armature: bpy.types.Armature, data_parent_empty: bpy.types.Object
+):
+    for pose_bone in armature.pose.bones:
+        if 'thumb.01' in pose_bone.name:
+            thumb_side = 'left' if '.L' in pose_bone.name else 'right'
+            thumb_cmc = _get_marker(
+                data_parent_empty, f"{thumb_side}_hand_thumb_cmc"
+            )
+            if thumb_cmc:
+                location_constraint = pose_bone.constraints.new('COPY_LOCATION')
+                location_constraint.target = thumb_cmc
+                pose_bone.constraints.move(1, 0)
+
+    # Change the targets of the hand constraints
+    # TODO: Delete this if default target markers change to these in the future
+    for side in ['left', 'right']:
+        hand_bone = armature.pose.bones[f'hand.{side[0].upper()}']
+
+        hand_middle_finger_mcp = _get_marker(data_parent_empty, f"{side}_hand_middle_finger_mcp")
+        hand_index_finger_mcp = _get_marker(data_parent_empty, f"{side}_hand_index_finger_mcp")
+
+        if hand_middle_finger_mcp and 'Damped Track' in hand_bone.constraints:
+            hand_bone.constraints['Damped Track'].target = hand_middle_finger_mcp
+        if hand_index_finger_mcp and 'Locked Track' in hand_bone.constraints:
+            hand_bone.constraints['Locked Track'].target = hand_index_finger_mcp
+
+    trunk_center_marker = _get_marker(data_parent_empty, 'trunk_center')
+    _add_damped_track(
+        armature.pose.bones["spine"],
+        trunk_center_marker,
+        "Metahuman_Spine_01_Correction",
+        'TRACK_NEGATIVE_Z',
+        0.055,
+    )
+
+    neck_center_marker = _get_marker(data_parent_empty, 'neck_center')
+    _add_damped_track(
+        armature.pose.bones["spine.001"],
+        neck_center_marker,
+        "Metahuman_Spine_04_Correction",
+        'TRACK_Z',
+        0.035,
+    )
+
+    # Create a new copy_location constraint to the neck bone to set its location to the neck_center marker
+    neck_location_constraint = armature.pose.bones["neck"].constraints.new('COPY_LOCATION')
+    neck_location_constraint.name = "Metahuman_Neck_Location_Correction"
+    neck_location_constraint.target = neck_center_marker
+
+    # Move the new constraint to the top of the stack
+    neck_constraints = armature.pose.bones["neck"].constraints
+    neck_constraints.move(len(neck_constraints) - 1, 0)
+
+    head_center_marker = _get_marker(data_parent_empty, 'head_center')
+    _add_damped_track(
+        armature.pose.bones["neck"],
+        head_center_marker,
+        "Metahuman_Neck_Correction",
+        'TRACK_Z',
+        0.11,
+    )
+
+    nose_marker = _get_marker(data_parent_empty, 'nose')
+    _add_damped_track(
+        armature.pose.bones["face"],
+        nose_marker,
+        "Metahuman_Head_Correction",
+        'TRACK_Z',
+        0.1,
+    )
+
+
+def _apply_daz_g8_1_edit_mode(armature: bpy.types.Armature, bone_info: dict):
+    # Parent the thigh bones to the pelvis
+    for bone in armature.data.edit_bones:
+        if 'thigh' in bone.name:
+            bone.use_connect = False
+            bone.parent = armature.data.edit_bones['pelvis']
+
+        if 'thumb.01' in bone.name:
+            thumb_side = 'left' if '.L' in bone.name else 'right'
+            bone.use_connect = False
+            # Set the new parent to the hand using uppercase first letter
+            bone.parent = armature.data.edit_bones[f'hand.{thumb_side[0].upper()}']
+
+            # Remove the thumb.carpal bone
+            thumb_carpal_name = f'thumb.carpal.{thumb_side[0].upper()}'
+            if thumb_carpal_name in armature.data.edit_bones:
+                armature.data.edit_bones.remove(
+                    armature.data.edit_bones[thumb_carpal_name]
+                )
+
+    # Change length of Spine.001 (chestLower) to compensate for new parent position
+    # 18 results from the 0.2 influence of the trunk_center marker above
+    spine_rotation = m.radians(18)
+    spine_length = bone_info['spine']['length']
+    spine_001_length = bone_info['spine.001']['length']
+    
+    spine_001_new_length = m.sqrt(
+        spine_length**2
+        + (spine_length + spine_001_length)**2
+        - 2 * spine_length * (spine_length + spine_001_length) * m.cos(spine_rotation)
+    )
+
+    armature.data.edit_bones['spine.001'].length = spine_001_new_length
+
+    print("New spine.001 length:", armature.data.edit_bones['spine.001'].length)
+
+    # Create the ForearmTwist bones and parent them to the forearm bones
+    for side in ['left', 'right']:
+        forearm_name = f'forearm.{side[0].upper()}'
+        if forearm_name not in armature.data.edit_bones:
+            continue
+
+        bone = armature.data.edit_bones[forearm_name]
+
+        # Duplicate bone
+        forearm_twist_bone = armature.data.edit_bones.new(
+            f'forearm_twist.{side[0].upper()}'
+        )
+        forearm_twist_bone.head = bone.head.copy()
+        forearm_twist_bone.tail = bone.tail.copy()
+        forearm_twist_bone.roll = bone.roll
+        forearm_twist_bone.use_connect = False
+
+        # Parent duplicate to source
+        forearm_twist_bone.parent = bone
+
+
+def _apply_daz_g8_1_pose_mode(
+    armature: bpy.types.Armature, data_parent_empty: bpy.types.Object
+):
+    for pose_bone in armature.pose.bones:
+        if 'thumb.01' in pose_bone.name:
+            thumb_side = 'left' if '.L' in pose_bone.name else 'right'
+            thumb_cmc = _get_marker(
+                data_parent_empty, f"{thumb_side}_hand_thumb_cmc"
+            )
+            if thumb_cmc:
+                bone_location_constraint = pose_bone.constraints.new('COPY_LOCATION')
+                bone_location_constraint.target = thumb_cmc
+                pose_bone.constraints.move(1, 0)
+
+    nose_marker = _get_marker(data_parent_empty, 'nose')
+    _add_damped_track(
+        armature.pose.bones["face"],
+        nose_marker,
+        "DazG8.1_Face_Correction",
+        'TRACK_Z',
+        0.6,
+    )
+
+    trunk_center_marker = _get_marker(data_parent_empty, 'trunk_center')
+
+    pelvis_constraint = armature.pose.bones["pelvis"].constraints.new('LOCKED_TRACK')
+    pelvis_constraint.name = "DazG8.1_Pelvis_Correction"
+    pelvis_constraint.target = trunk_center_marker
+    pelvis_constraint.track_axis = 'TRACK_Y'
+    pelvis_constraint.lock_axis = 'LOCK_X'
+    pelvis_constraint.influence = 0.87
+
+    _add_damped_track(
+        armature.pose.bones["spine"],
+        trunk_center_marker,
+        "DazG8.1_Spine_Correction",
+        'TRACK_NEGATIVE_Z',
+        0.2,
+    )
+
+    for side in ['left', 'right']:
+        twist_bone_name = f'forearm_twist.{side[0].upper()}'
+        hand_bone_name = f'hand.{side[0].upper()}'
+        forearm_bone_name = f'forearm.{side[0].upper()}'
+
+        if (
+            twist_bone_name in armature.pose.bones
+            and hand_bone_name in armature.pose.bones
+        ):
+            forearm_twist_bone = armature.pose.bones[twist_bone_name]
+            hand_bone = armature.pose.bones[hand_bone_name]
+
+            copy_rotation_constraint = forearm_twist_bone.constraints.new('COPY_ROTATION')
+            copy_rotation_constraint.target = armature
+            copy_rotation_constraint.subtarget = hand_bone.name
+            copy_rotation_constraint.influence = 0.5
+            copy_rotation_constraint.use_x = False
+            copy_rotation_constraint.use_z = False
+            copy_rotation_constraint.target_space = 'LOCAL'
+            copy_rotation_constraint.owner_space = 'LOCAL'
+
+        if forearm_bone_name in armature.pose.bones:
+            forearm_bone = armature.pose.bones[forearm_bone_name]
+            thumb_cmc = _get_marker(data_parent_empty, f"{side}_hand_thumb_cmc")
+
+            bend_bone_constraint = forearm_bone.constraints.new('LOCKED_TRACK')
+            bend_bone_constraint.name = 'DazG8.1_Forearm_Bend_Correction'
+            bend_bone_constraint.target = thumb_cmc
+            bend_bone_constraint.track_axis = 'TRACK_Z'
+            bend_bone_constraint.lock_axis = 'LOCK_Y'
+            bend_bone_constraint.influence = 0.35
+
 
 def set_armature_rest_pose(
     data_parent_empty: bpy.types.Object,
@@ -17,7 +310,7 @@ def set_armature_rest_pose(
     # Select the armature
     armature.select_set(True)
 
-    # Get the bone info (postions and lengths)
+    # Get the bone info (positions and lengths)
     bone_info = get_bone_info(armature)
 
     rest_pose_rotations = rest_pose_type_rotations[rest_pose_type]
@@ -25,314 +318,21 @@ def set_armature_rest_pose(
     # Enter Edit Mode
     bpy.ops.object.mode_set(mode='EDIT')
 
-    # Set the rest pose rotations
-    for bone in armature.data.edit_bones:
-        if bone.name in rest_pose_rotations:
+    # Apply base rest pose rotations
+    _apply_base_rotations(armature, bone_info, rest_pose_rotations)
 
-            # If the bone is part of the palm, move its head to its parent
-            # as it is not connected and didn't move with its parent rotation
-            if 'palm' in bone.name or 'thumb.carpal' in bone.name:
-                bone.head = bone.parent.head
-
-            # TODO: Check again the metahuman metacarpal offset values
-            # TODO: Generalize this for other rest pose types if needed
-            # If the armature is a metahuman, move the metacarpals using the offset info
-            # if rest_pose_type == 'metahuman':
-            #     if bone.name in ['palm.01.L', 'palm.02.L', 'palm.03.L', 'palm.04.L'] and 'position_offset' in rest_pose_rotations[bone.name].keys():
-            #         print("Bone head position:", bone.head)
-            #         print("Bone tail position:", bone_info[bone.name]['tail_position'])
-            #         print("Bone length:", bone_info[bone.name]['length'])
-            #         # Get the offset distance from the hand bone head
-            #         offset_distance = rest_pose_rotations[bone.name]['position_offset']['wrist_newbonehead_to_wrist_mcp_ratio'] * bone_info[bone.name]['length']
-            #         # Create the offset vector
-            #         offset_vector = Vector([0, 0, offset_distance])
-            #         # Get the rotation matrix
-            #         rotation_matrix = Euler(
-            #             Vector(rest_pose_rotations[bone.name]['position_offset']['rotation']),
-            #                 'XYZ',
-            #             ).to_matrix()
-            #         # Rotate the offset vector
-            #         bone.head = (
-            #             bone.parent.head
-            #             + rotation_matrix @ offset_vector
-            #         )
-            #         # Update the bone length
-            #         bone_info[bone.name]['length'] = rest_pose_rotations[bone.name]['position_offset']['newbonehead_mcp_to_wrist_mcp_ratio'] * bone_info[bone.name]['length']
-            #         print("Bone head position:", bone.head)
-            #         print("Bone tail position:", bone_info[bone.name]['tail_position'])
-            #         print("Bone length:", bone_info[bone.name]['length'])
-
-            bone_vector = Vector(
-                [0, 0, bone_info[bone.name]['length']]
-            )
-
-            # Get the rotation matrix
-            rotation_matrix = Euler(
-                Vector(rest_pose_rotations[bone.name]['rotation']),
-                'XYZ',
-            ).to_matrix()
-
-            # Rotate the bone vector
-            bone.tail = (
-                bone.head
-                + rotation_matrix @ bone_vector
-            )
-
-            # Assign the roll to the bone
-            bone.roll = rest_pose_rotations[bone.name]['roll']
-
-    # In case the rest pose type is metahuman, parent the thigh bones to the pelvis
-    # and parent the thumb.01 bones to the hand
     if rest_pose_type == 'metahuman':
-        for bone in armature.data.edit_bones:
-            if 'thigh' in bone.name:
-                bone.use_connect = False
-                bone.parent = armature.data.edit_bones['pelvis']
+        _apply_metahuman_edit_mode(armature, bone_info, rest_pose_rotations)
+    elif rest_pose_type == 'daz_g8.1':
+        _apply_daz_g8_1_edit_mode(armature, bone_info)
 
-            if 'thumb.01' in bone.name:
-                thumb_side = 'left' if '.L' in bone.name else 'right'
+    # Enter Pose Mode
+    bpy.ops.object.mode_set(mode='POSE')
 
-                bone.use_connect = False
-                # Set the new parent to the hand using the uppercase first letter of side
-                bone.parent = armature.data.edit_bones[f'hand.{thumb_side[0].upper()}']
-
-                # Get the thumb cmc marker
-                thumb_cmc = [
-                    marker for marker in data_parent_empty.children_recursive
-                    if thumb_side + '_hand_thumb_cmc' in marker.name
-                ][0]
-
-                bone_location_constraint = armature.pose.bones[bone.name].constraints.new('COPY_LOCATION')
-                bone_location_constraint.target = thumb_cmc
-                armature.pose.bones[bone.name].constraints.move(1, 0)
-
-                # Remove the thumb.carpal bone
-                if 'thumb.carpal.' + thumb_side[0].upper() in armature.data.edit_bones:
-                    armature.data.edit_bones.remove(armature.data.edit_bones['thumb.carpal.' + thumb_side[0].upper()])
-
-            # Disconnect the shoulder and neck bones from parent so spine.001 can have custom rotation
-            if 'shoulder' in bone.name or 'neck' in bone.name:
-                bone.use_connect = False
-
-        # Change the targets of the hand constraints
-        # TODO: Delete this code if the default target markers change to these ones in the future
-        for side in ['left', 'right']:
-            hand_bone = armature.pose.bones['hand' + '.' + side[0].upper()]
-
-            # Get the hand_middle_finger_mcp
-            hand_middle_finger_mcp = [
-                marker for marker in data_parent_empty.children_recursive
-                if side + '_hand_middle_finger_mcp' in marker.name
-            ][0]
-
-            # Get the hand_index_finger_mcp
-            hand_index_finger_mcp = [
-                marker for marker in data_parent_empty.children_recursive
-                if side + '_hand_index_finger_mcp' in marker.name
-            ][0]
-
-            hand_bone.constraints['Damped Track'].target = hand_middle_finger_mcp
-            hand_bone.constraints['Locked Track'].target = hand_index_finger_mcp
-
-        # Get the trunk_center marker
-        trunk_center_marker = [
-            marker for marker in data_parent_empty.children_recursive
-            if 'trunk_center' in marker.name
-        ][0]
-
-        # Create a new damped_tracked constraint for the spine (spine_01) and set it to the -z-axis
-        new_constraint = armature.pose.bones["spine"].constraints.new('DAMPED_TRACK')
-        new_constraint.name = "Metahuman_Spine_01_Correction"
-        
-        # Configure the constraint
-        new_constraint.target = trunk_center_marker
-        new_constraint.track_axis = 'TRACK_NEGATIVE_Z'
-        new_constraint.influence = 0.055
-
-        # Change the length of Spine.001 (spine_04) to compensate for the new parent position
-        spine_rotation = rest_pose_rotations['spine']['rotation'][0]
-        spine_length = bone_info['spine']['length']
-        spine_001_length = bone_info['spine.001']['length']
-        spine_001_new_length = m.sqrt(spine_length**2 + (spine_length+spine_001_length)**2 - 2*spine_length*(spine_length+spine_001_length)*m.cos(spine_rotation))
-
-        armature.data.edit_bones['spine.001'].length = spine_001_new_length
-
-        # Get the neck_center marker
-        neck_center_marker = [
-            marker for marker in data_parent_empty.children_recursive
-            if 'neck_center' in marker.name
-        ][0]
-
-        # Create a new damped_tracked constraint for the spine_04 (spine.001)
-        new_constraint = armature.pose.bones["spine.001"].constraints.new('DAMPED_TRACK')
-        new_constraint.name = "Metahuman_Spine_04_Correction"
-        new_constraint.target = neck_center_marker
-        new_constraint.track_axis = 'TRACK_Z'
-        new_constraint.influence = 0.035
-
-        # Create a new copy_location constraint to the neck bone to set its location to the neck_center marker
-        new_constraint = armature.pose.bones["neck"].constraints.new('COPY_LOCATION')
-        new_constraint.name = "Metahuman_Neck_Location_Correction"
-        new_constraint.target = neck_center_marker
-
-        # Move the new constraint to the top of the stack
-        neck_constraints = armature.pose.bones["neck"].constraints
-        neck_constraints.move(len(neck_constraints) - 1, 0)
-
-        # Get the head_center marker
-        head_center_marker = [
-            marker for marker in data_parent_empty.children_recursive
-            if 'head_center' in marker.name
-        ][0]
-
-        # Create a new damped_tracked constraint for the neck bone and set it to the -z-axis with 0.1 influence
-        new_constraint = armature.pose.bones["neck"].constraints.new('DAMPED_TRACK')
-        new_constraint.name = "Metahuman_Neck_Correction"
-        new_constraint.target = head_center_marker
-        new_constraint.track_axis = 'TRACK_Z'
-        new_constraint.influence = 0.11
-
-        # Get the nose marker
-        nose_marker = [
-            marker for marker in data_parent_empty.children_recursive
-            if 'nose' in marker.name
-        ][0]
-
-        # Create a new damped_tracked constraint for the head (face) bone and set it to the -z-axis with 0.1 influence
-        new_constraint = armature.pose.bones["face"].constraints.new('DAMPED_TRACK')
-        new_constraint.name = "Metahuman_Head_Correction"
-        new_constraint.target = nose_marker
-        new_constraint.track_axis = 'TRACK_Z'
-        new_constraint.influence = 0.1
-
-
-    if rest_pose_type == 'daz_g8.1':
-        # Parent the thigh bones to the pelvis
-        for bone in armature.data.edit_bones:
-            if 'thigh' in bone.name:
-                bone.use_connect = False
-                bone.parent = armature.data.edit_bones['pelvis']
-
-            if 'thumb.01' in bone.name:
-                thumb_side = 'left' if '.L' in bone.name else 'right'
-
-                bone.use_connect = False
-                # Set the new parent to the hand using the uppercase first letter of side
-                bone.parent = armature.data.edit_bones[f'hand.{thumb_side[0].upper()}']
-
-                # Get the thumb cmc marker
-                thumb_cmc = [
-                    marker for marker in data_parent_empty.children_recursive
-                    if thumb_side + '_hand_thumb_cmc' in marker.name
-                ][0]
-
-                bone_location_constraint = armature.pose.bones[bone.name].constraints.new('COPY_LOCATION')
-                bone_location_constraint.target = thumb_cmc
-                armature.pose.bones[bone.name].constraints.move(1, 0)
-
-                # Remove the thumb.carpal bone
-                if 'thumb.carpal.' + thumb_side[0].upper() in armature.data.edit_bones:
-                    armature.data.edit_bones.remove(armature.data.edit_bones['thumb.carpal.' + thumb_side[0].upper()])
-
-
-        # Create a new damped_tracked constraint for the face and set it to the z-axis with 0.6 influence
-        new_constraint = armature.pose.bones["face"].constraints.new('DAMPED_TRACK')
-        new_constraint.name = "DazG8.1_Face_Correction"
-
-        # Get the nose marker
-        nose_marker = [
-            marker for marker in data_parent_empty.children_recursive
-            if 'nose' in marker.name
-        ][0]
-        new_constraint.target = nose_marker
-        new_constraint.track_axis = 'TRACK_Z'
-        new_constraint.influence = 0.6
-
-        # Create a new locked_tracked constraint for the pelvis and set it to the y-axis with 0.87 influence
-        new_constraint = armature.pose.bones["pelvis"].constraints.new('LOCKED_TRACK')
-        new_constraint.name = "DazG8.1_Pelvis_Correction"
-
-        # Get the trunk_center marker
-        trunk_center_marker = [
-            marker for marker in data_parent_empty.children_recursive
-            if 'trunk_center' in marker.name
-        ][0]
-        new_constraint.target = trunk_center_marker
-        new_constraint.track_axis = 'TRACK_Y'
-        new_constraint.lock_axis = 'LOCK_X'
-        new_constraint.influence = 0.87
-
-        # Create a new damped_tracked constraint for the spine (abdomenLower) and set it to the -z-axis with 0.2 influence
-        new_constraint = armature.pose.bones["spine"].constraints.new('DAMPED_TRACK')
-        new_constraint.name = "DazG8.1_Spine_Correction"
-        
-        # Reuse the trunk_center marker
-        new_constraint.target = trunk_center_marker
-        new_constraint.track_axis = 'TRACK_NEGATIVE_Z'
-        new_constraint.influence = 0.2
-
-        # Change the length of Spine.001 (chestLower) to compensate for the new parent position
-        spine_rotation = m.radians(18) # 18 results from the 0.2 influence of the trunk_center marker above
-        spine_length = bone_info['spine']['length']
-        spine_001_length = bone_info['spine.001']['length']
-        spine_001_new_length = m.sqrt(spine_length**2 + (spine_length+spine_001_length)**2 - 2*spine_length*(spine_length+spine_001_length)*m.cos(spine_rotation))
-
-        armature.data.edit_bones['spine.001'].length = spine_001_new_length
-
-        print("New spine.001 length:", armature.data.edit_bones['spine.001'].length)
-
-        # Create the ForearmTwist bones and parent them to the forearm bones
-        for side in ['left', 'right']:
-            if not 'forearm.' + side[0].upper() in armature.data.edit_bones:
-                continue
-
-            bone = armature.data.edit_bones['forearm.' + side[0].upper()]
-
-            # Duplicate bone
-            forearm_twist_bone = armature.data.edit_bones.new('forearm_twist' + '.' + side[0].upper())
-            
-            forearm_twist_bone.head = bone.head.copy()
-            forearm_twist_bone.tail = bone.tail.copy()
-            forearm_twist_bone.roll = bone.roll
-            forearm_twist_bone.use_connect = False
-
-            # Parent duplicate to source
-            forearm_twist_bone.parent = bone
-
-        # Add a copy rotation constraint to the forearm_twist bones to copy the hand bone rotation
-        # Also add a locked tracked constraint to the forearm_bend bones to the thumb cmc marker
-        # Enter Pose Mode
-        bpy.ops.object.mode_set(mode='POSE')
-
-        for side in ['left', 'right']:
-            forearm_twist_bone = armature.pose.bones['forearm_twist' + '.' + side[0].upper()]
-
-            hand_bone = armature.pose.bones['hand' + '.' + side[0].upper()]
-
-            copy_rotation_constraint = forearm_twist_bone.constraints.new('COPY_ROTATION')
-            copy_rotation_constraint.target = armature
-            copy_rotation_constraint.subtarget = hand_bone.name
-            copy_rotation_constraint.influence = 0.5
-            copy_rotation_constraint.use_x = False
-            copy_rotation_constraint.use_z = False
-            copy_rotation_constraint.target_space = 'LOCAL'
-            copy_rotation_constraint.owner_space = 'LOCAL'
-            
-            forearm_bone = armature.pose.bones['forearm' + '.' + side[0].upper()]
-            # Get the thumb cmc marker
-            thumb_cmc = [
-                marker for marker in data_parent_empty.children_recursive
-                if side + '_hand_thumb_cmc' in marker.name
-            ][0]
-
-            # Add a locked track constraint to the forearm bone to point to the thumb cmc marker
-            bend_bone_constraint = forearm_bone.constraints.new('LOCKED_TRACK')
-            bend_bone_constraint.name = 'DazG8.1_Forearm_Bend_Correction'
-            bend_bone_constraint.target = thumb_cmc
-            bend_bone_constraint.track_axis = 'TRACK_Z'
-            bend_bone_constraint.lock_axis = 'LOCK_Y'
-            bend_bone_constraint.influence = 0.35
-
+    if rest_pose_type == 'metahuman':
+        _apply_metahuman_pose_mode(armature, data_parent_empty)
+    elif rest_pose_type == 'daz_g8.1':
+        _apply_daz_g8_1_pose_mode(armature, data_parent_empty)
 
     # Go back to Object Mode
-    bpy.ops.object.mode_set(mode='OBJECT')        
+    bpy.ops.object.mode_set(mode='OBJECT')

--- a/ajc27_freemocap_blender_addon/core_functions/export_3d_model/helpers/set_armature_rest_pose.py
+++ b/ajc27_freemocap_blender_addon/core_functions/export_3d_model/helpers/set_armature_rest_pose.py
@@ -110,6 +110,10 @@ def set_armature_rest_pose(
                 if 'thumb.carpal.' + thumb_side[0].upper() in armature.data.edit_bones:
                     armature.data.edit_bones.remove(armature.data.edit_bones['thumb.carpal.' + thumb_side[0].upper()])
 
+            # Disconnect the shoulder and neck bones from parent so spine.001 can have custom rotation
+            if 'shoulder' in bone.name or 'neck' in bone.name:
+                bone.use_connect = False
+
         # Change the targets of the hand constraints
         # TODO: Delete this code if the default target markers change to these ones in the future
         for side in ['left', 'right']:
@@ -129,6 +133,78 @@ def set_armature_rest_pose(
 
             hand_bone.constraints['Damped Track'].target = hand_middle_finger_mcp
             hand_bone.constraints['Locked Track'].target = hand_index_finger_mcp
+
+        # Get the trunk_center marker
+        trunk_center_marker = [
+            marker for marker in data_parent_empty.children_recursive
+            if 'trunk_center' in marker.name
+        ][0]
+
+        # Create a new damped_tracked constraint for the spine (spine_01) and set it to the -z-axis
+        new_constraint = armature.pose.bones["spine"].constraints.new('DAMPED_TRACK')
+        new_constraint.name = "Metahuman_Spine_01_Correction"
+        
+        # Configure the constraint
+        new_constraint.target = trunk_center_marker
+        new_constraint.track_axis = 'TRACK_NEGATIVE_Z'
+        new_constraint.influence = 0.055
+
+        # Change the length of Spine.001 (spine_04) to compensate for the new parent position
+        spine_rotation = rest_pose_rotations['spine']['rotation'][0]
+        spine_length = bone_info['spine']['length']
+        spine_001_length = bone_info['spine.001']['length']
+        spine_001_new_length = m.sqrt(spine_length**2 + (spine_length+spine_001_length)**2 - 2*spine_length*(spine_length+spine_001_length)*m.cos(spine_rotation))
+
+        armature.data.edit_bones['spine.001'].length = spine_001_new_length
+
+        # Get the neck_center marker
+        neck_center_marker = [
+            marker for marker in data_parent_empty.children_recursive
+            if 'neck_center' in marker.name
+        ][0]
+
+        # Create a new damped_tracked constraint for the spine_04 (spine.001)
+        new_constraint = armature.pose.bones["spine.001"].constraints.new('DAMPED_TRACK')
+        new_constraint.name = "Metahuman_Spine_04_Correction"
+        new_constraint.target = neck_center_marker
+        new_constraint.track_axis = 'TRACK_Z'
+        new_constraint.influence = 0.035
+
+        # Create a new copy_location constraint to the neck bone to set its location to the neck_center marker
+        new_constraint = armature.pose.bones["neck"].constraints.new('COPY_LOCATION')
+        new_constraint.name = "Metahuman_Neck_Location_Correction"
+        new_constraint.target = neck_center_marker
+
+        # Move the new constraint to the top of the stack
+        neck_constraints = armature.pose.bones["neck"].constraints
+        neck_constraints.move(len(neck_constraints) - 1, 0)
+
+        # Get the head_center marker
+        head_center_marker = [
+            marker for marker in data_parent_empty.children_recursive
+            if 'head_center' in marker.name
+        ][0]
+
+        # Create a new damped_tracked constraint for the neck bone and set it to the -z-axis with 0.1 influence
+        new_constraint = armature.pose.bones["neck"].constraints.new('DAMPED_TRACK')
+        new_constraint.name = "Metahuman_Neck_Correction"
+        new_constraint.target = head_center_marker
+        new_constraint.track_axis = 'TRACK_Z'
+        new_constraint.influence = 0.11
+
+        # Get the nose marker
+        nose_marker = [
+            marker for marker in data_parent_empty.children_recursive
+            if 'nose' in marker.name
+        ][0]
+
+        # Create a new damped_tracked constraint for the head (face) bone and set it to the -z-axis with 0.1 influence
+        new_constraint = armature.pose.bones["face"].constraints.new('DAMPED_TRACK')
+        new_constraint.name = "Metahuman_Head_Correction"
+        new_constraint.target = nose_marker
+        new_constraint.track_axis = 'TRACK_Z'
+        new_constraint.influence = 0.1
+
 
     if rest_pose_type == 'daz_g8.1':
         # Parent the thigh bones to the pelvis


### PR DESCRIPTION
Here is an improvement to the Metahuman rest pose of the exported model. It adds some bone constraints to match the original metahuman bones in the spine and neck segments.

Also it has a refactor of the export code to simplify the use of different armature types.