### PR TITLE
flexibility for groundplane calibration names

### DIFF
--- a/freemocap_blender_addon/core_functions/add_capture_cameras/add_capture_cameras.py
+++ b/freemocap_blender_addon/core_functions/add_capture_cameras/add_capture_cameras.py
@@ -87,13 +87,15 @@ def add_capture_cameras(
         with open(calibration_file_path, 'r') as file:
             data = toml.load(file)
 
-    # Check if the groundplane_calibration variable exists and is true
-    if 'groundplane_calibration' not in data['metadata'].keys():
-        print('Groundplane calibration is not enabled')
-        return
-    
-    if not data['metadata']['groundplane_calibration']:
-        print('Groundplane calibration is not enabled')
+    metadata = data.get("metadata", {})
+
+    groundplane_applied = metadata.get(
+        "groundplane_applied",
+        metadata.get("groundplane_calibration", False),
+    )
+
+    if not groundplane_applied:
+        print("Groundplane calibration has not been applied")
         return
 
     # Extract camera information into a dictionary

--- a/freemocap_blender_addon/data_models/freemocap_data/freemocap_data_model.py
+++ b/freemocap_blender_addon/data_models/freemocap_data/freemocap_data_model.py
@@ -181,17 +181,27 @@ class FreemocapData:
         else:
             metadata = {}
 
-        groundplane_calibration:bool = False #set default value
-        if data_paths.calibration_toml is not None: #for single-cam recording cases where there is no calibration file and if tomllib is not available
-            if tomllib is not None:
-                with open (data_paths.calibration_toml, "rb") as f:
-                    calibration_data = tomllib.load(f)
-                groundplane_calibration = calibration_data.get('metadata', {}).get('groundplane_calibration', False) #for backwards compatibility with files that do not have this key
-            elif toml is not None:
-                with open (data_paths.calibration_toml, "r", encoding="utf-8") as f:
-                    calibration_data = toml.load(f)
-                groundplane_calibration = calibration_data.get('metadata', {}).get('groundplane_calibration', False) #for backwards compatibility with files that do not have this key
+        groundplane_calibration: bool = False
 
+        if data_paths.calibration_toml is not None:
+            if tomllib is not None:
+                with open(data_paths.calibration_toml, "rb") as f:
+                    calibration_data = tomllib.load(f)
+            elif toml is not None:
+                with open(data_paths.calibration_toml, "r", encoding="utf-8") as f:
+                    calibration_data = toml.load(f)
+            else:
+                raise ImportError(
+                    "Could not load calibration TOML: neither tomllib nor toml is available."
+                )
+
+            calibration_metadata = calibration_data.get("metadata", {})
+
+            groundplane_calibration = calibration_metadata.get(
+                "groundplane_applied",
+                calibration_metadata.get("groundplane_calibration", False),
+            )
+            
         return cls.from_data(
             body_frame_name_xyz=np.load(data_paths.body_npy) / scale,
             right_hand_frame_name_xyz=np.load(data_paths.right_hand_npy) / scale,


### PR DESCRIPTION
The groundplane calibration was not being properly retained in the Blender code, as we were looking for the 'groundplane_calibration' keyword when the 2.0 calibration changed it to the 'groundplane_applied' keyword. This version should make it so that both are accepted. 