### PR TITLE
Fix missing hand issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ dmypy.json
 
 desktop.ini
 freemocap_blender_addon/assets/skelly_full_mesh_20k_faces.blend1
+CLAUDE.md

--- a/freemocap_blender_addon/core_functions/create_rig/add_rig_bone_method.py
+++ b/freemocap_blender_addon/core_functions/create_rig/add_rig_bone_method.py
@@ -100,7 +100,7 @@ def add_rig_by_bone(
                 rig_bone.head = parent_bone.tail
 
         # Get the bone vector
-        if inv_bone_name_map[bone] not in bone_data:
+        if inv_bone_name_map[bone] not in bone_data or m.isnan(bone_data[inv_bone_name_map[bone]]["median"]):
             bone_vector = mathutils.Vector(
                 [0, 0, armature_definition[bone].default_length]
             )

--- a/freemocap_blender_addon/core_functions/empties/creation/create_empty_from_trajectory.py
+++ b/freemocap_blender_addon/core_functions/empties/creation/create_empty_from_trajectory.py
@@ -1,4 +1,4 @@
-from typing import List, Union, Dict
+from typing import List, Optional, Union, Dict
 import bpy
 import numpy as np
 
@@ -9,27 +9,52 @@ def create_empties(
     empty_scale: float,
     empty_type: str,
     parent_object: bpy.types.Object,
+    fallback_trajectory_fr_xyz: Optional[np.ndarray] = None,
 ) -> Dict[str, bpy.types.Object]:
-    
+
     if isinstance(names_list, str):
         names_list = [names_list] * trajectory_frame_marker_xyz.shape[1]
-    
+
     empties = {}
     number_of_trajectories = trajectory_frame_marker_xyz.shape[1]
-    
+
     for marker_number in range(number_of_trajectories):
         trajectory_name = names_list[marker_number]
         trajectory_fr_xyz = trajectory_frame_marker_xyz[:, marker_number, :]
-        
+
         empties[trajectory_name] = create_keyframed_empty_from_3d_trajectory_data(
             trajectory_fr_xyz=trajectory_fr_xyz,
             trajectory_name=trajectory_name,
             parent_object=parent_object,
             empty_scale=empty_scale,
             empty_type=empty_type,
+            fallback_trajectory_fr_xyz=fallback_trajectory_fr_xyz,
         )
 
     return empties
+
+
+def _fill_nan_1d(values: np.ndarray, fallback_values: Optional[np.ndarray] = None) -> np.ndarray:
+    """Forward-fill NaN samples from the last valid value, back-fill any leading NaNs,
+    and fall back to `fallback_values` (or zero, if none given) if every sample is NaN
+    (e.g. an entirely missing trajectory)."""
+    nan_mask = np.isnan(values)
+    if not nan_mask.any():
+        return values
+    if nan_mask.all():
+        if fallback_values is None:
+            return np.zeros_like(values)
+        # The fallback itself may have gaps (e.g. the wrist trajectory is also partially missing) -
+        # fill it against zero rather than propagating NaN.
+        return _fill_nan_1d(fallback_values)
+
+    filled = values.copy()
+    valid_indices = np.flatnonzero(~nan_mask)
+    hold_indices = np.maximum.accumulate(np.where(~nan_mask, np.arange(len(values)), 0))
+    filled = filled[hold_indices]
+    filled[: valid_indices[0]] = values[valid_indices[0]]
+    return filled
+
 
 def create_keyframed_empty_from_3d_trajectory_data(
     trajectory_fr_xyz: np.ndarray,
@@ -37,6 +62,7 @@ def create_keyframed_empty_from_3d_trajectory_data(
     parent_object: bpy.types.Object|None=None,
     empty_scale: float = 0.1,
     empty_type: str = "PLAIN_AXES",
+    fallback_trajectory_fr_xyz: Optional[np.ndarray] = None,
 ) -> bpy.types.Object:
     
     # Create empty object
@@ -77,7 +103,8 @@ def create_keyframed_empty_from_3d_trajectory_data(
         # Create a flattened array of [frame0, value0, frame1, value1, ...]
         co = np.empty(2 * num_frames, dtype=np.float32)
         co[0::2] = frames  # Frame numbers
-        co[1::2] = trajectory_fr_xyz[:, axis_idx]  # Axis values
+        fallback_values = fallback_trajectory_fr_xyz[:, axis_idx] if fallback_trajectory_fr_xyz is not None else None
+        co[1::2] = _fill_nan_1d(trajectory_fr_xyz[:, axis_idx], fallback_values)  # Axis values, with NaNs filled
 
         # Assign all keyframes at once
         fcurve.keyframe_points.foreach_set("co", co)

--- a/freemocap_blender_addon/core_functions/empties/creation/create_freemocap_empties.py
+++ b/freemocap_blender_addon/core_functions/empties/creation/create_freemocap_empties.py
@@ -31,6 +31,7 @@ def create_freemocap_empties(handler: FreemocapDataHandler,
             empty_scale=hand_empty_scale,
             empty_type="PLAIN_AXES",
             parent_object=parent_object,
+            fallback_trajectory_fr_xyz=handler.trajectories["right_wrist"],
         )
         # left hand trajectories
         empties["hands"]["left"] = create_empties(
@@ -39,6 +40,7 @@ def create_freemocap_empties(handler: FreemocapDataHandler,
             empty_scale=hand_empty_scale,
             empty_type="PLAIN_AXES",
             parent_object=parent_object,
+            fallback_trajectory_fr_xyz=handler.trajectories["left_wrist"],
         )
 
         empties["other"] = {}

--- a/freemocap_blender_addon/core_functions/meshes/skelly_mesh/helpers/rotate_vertex_groups.py
+++ b/freemocap_blender_addon/core_functions/meshes/skelly_mesh/helpers/rotate_vertex_groups.py
@@ -1,6 +1,12 @@
+import math
+
 import bpy
 import bmesh
 from mathutils import Matrix
+
+
+def _is_invalid_vector(vector) -> bool:
+    return vector.length == 0 or any(math.isnan(c) for c in vector)
 
 
 def rotate_vertex_groups(target_mesh, vertex_groups, bone_info):
@@ -40,9 +46,9 @@ def rotate_vertex_groups(target_mesh, vertex_groups, bone_info):
             # Get the bone vector
             bone_vector = bone_info[info['armature_bone']]['tail_position'] - bone_info[info['armature_bone']]['head_position']
 
-            if bone_vector.length == 0 or vertex_group_vector.length == 0:
+            if _is_invalid_vector(bone_vector) or _is_invalid_vector(vertex_group_vector):
                 print(f"Skipping rotation for vertex group '{vertex_group}': "
-                      f"zero-length bone vector (no valid mocap data for '{info['armature_bone']}') — leaving unrotated.")
+                      f"invalid bone vector (zero-length or NaN) for '{info['armature_bone']}' — leaving unrotated.")
                 continue
 
             # Normalize the vectors

--- a/freemocap_blender_addon/core_functions/meshes/skelly_mesh/helpers/rotate_vertex_groups.py
+++ b/freemocap_blender_addon/core_functions/meshes/skelly_mesh/helpers/rotate_vertex_groups.py
@@ -40,6 +40,11 @@ def rotate_vertex_groups(target_mesh, vertex_groups, bone_info):
             # Get the bone vector
             bone_vector = bone_info[info['armature_bone']]['tail_position'] - bone_info[info['armature_bone']]['head_position']
 
+            if bone_vector.length == 0 or vertex_group_vector.length == 0:
+                print(f"Skipping rotation for vertex group '{vertex_group}': "
+                      f"zero-length bone vector (no valid mocap data for '{info['armature_bone']}') — leaving unrotated.")
+                continue
+
             # Normalize the vectors
             vertex_group_vector.normalize()
             bone_vector.normalize()

--- a/freemocap_blender_addon/core_functions/meshes/skelly_mesh/helpers/scale_vertex_groups.py
+++ b/freemocap_blender_addon/core_functions/meshes/skelly_mesh/helpers/scale_vertex_groups.py
@@ -1,3 +1,5 @@
+import math
+
 import bpy
 import bmesh
 from mathutils import Vector, Matrix
@@ -49,6 +51,12 @@ def scale_vertex_groups(target_mesh, vertex_groups, bone_info):
                 bone_length = bone_info['pelvis.L']['length'] + bone_info['pelvis.R']['length']
             else:
                 bone_length = bone_info[info['armature_bone']]['length']
+
+            head_position = bone_info[info['armature_bone']]['head_position']
+            if math.isnan(bone_length) or any(math.isnan(c) for c in head_position):
+                print(f"Skipping scaling for vertex group '{vertex_group}': "
+                      f"invalid (NaN) bone data for '{info['armature_bone']}' — leaving unscaled.")
+                continue
 
             # Get the scale ratio using the bone length
             scale_ratio = bone_length / origin_end_distance

--- a/freemocap_blender_addon/core_functions/meshes/skelly_mesh/helpers/translate_vertex_groups.py
+++ b/freemocap_blender_addon/core_functions/meshes/skelly_mesh/helpers/translate_vertex_groups.py
@@ -1,3 +1,5 @@
+import math
+
 import bpy
 import bmesh
 from mathutils import Vector
@@ -33,6 +35,12 @@ def translate_vertex_groups(target_mesh, vertex_groups, bone_info):
 
         # Calculate distance vector
         bone_position = bone_info[info['armature_bone']]['head_position']
+
+        if any(math.isnan(c) for c in bone_position):
+            print(f"Skipping translation for vertex group '{vertex_group}': "
+                  f"invalid (NaN) bone position for '{info['armature_bone']}' — leaving untranslated.")
+            continue
+
         delta_vector = Vector((
             bone_position[0] - origin_vertex.co[0],
             bone_position[1] - origin_vertex.co[1],

--- a/freemocap_blender_addon/freemocap_data_handler/operations/enforce_rigid_bodies/calculate_bone_length_statistics.py
+++ b/freemocap_blender_addon/freemocap_data_handler/operations/enforce_rigid_bodies/calculate_bone_length_statistics.py
@@ -34,14 +34,20 @@ def calculate_bone_length_statistics(trajectories: Dict[str, np.ndarray],
     print(f'Bone lengths calculated successfully!\n bones: \n{list(bone_definitions.keys())}')
     # Update the length median and stdev values for each bone
     for name, bone in bone_definitions.items():
-        # print(f'Calculating median and stdev for bone: {name}...')
         # Exclude posible length NaN (produced by an empty with NaN values as position) values from the median and standard deviation
-        bone.median = statistics.median(
-            [length for length in bone.lengths if not math.isnan(length)])
-        # virtual_bone['median'] = statistics.median(virtual_bone['lengths'])
-        bone.stdev = statistics.stdev(
-            [length for length in bone.lengths if not math.isnan(length)])
-        # virtual_bone['stdev'] = statistics.stdev(virtual_bone['lengths'])
+        valid_lengths = [length for length in bone.lengths if not math.isnan(length)]
+
+        if len(valid_lengths) == 0:
+            # No valid detections for this bone in the whole recording - leave it out of rigid-bone enforcement entirely.
+            bone.median = math.nan
+            bone.stdev = math.nan
+        elif len(valid_lengths) == 1:
+            # stdev requires at least two data points.
+            bone.median = valid_lengths[0]
+            bone.stdev = 0.0
+        else:
+            bone.median = statistics.median(valid_lengths)
+            bone.stdev = statistics.stdev(valid_lengths)
 
     print(f'Bone length statistics calculated successfully!')
 


### PR DESCRIPTION
The addon was failing when presented with videos that don't have hands. this led to unexpected failures when the capture involved sitting at a desk. This PR handles missing hand (and other bone data) throughout the pipeline, from mesh fitting to bvh export. For the hands in particular, if they are missing at the final export step they are attached to the wrist. I'm sure this could be improved upon (create a default hand and put it in a neutral position) but for now it just attaches the empties at the wrist.